### PR TITLE
chore: bump OFO version

### DIFF
--- a/environment/ofo/ofo.yaml
+++ b/environment/ofo/ofo.yaml
@@ -1488,7 +1488,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: ghcr.io/open-feature/open-feature-operator:v0.2.33
+        image: ghcr.io/open-feature/open-feature-operator:v0.2.34
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:


### PR DESCRIPTION
## This PR

- updates OFO version to [0.2.34](https://github.com/open-feature/open-feature-operator/releases/tag/v0.2.34)

### Notes

This updates the version of flagd to `v0.5.2`.

